### PR TITLE
Making TLS optional

### DIFF
--- a/cmd/canary/canary.go
+++ b/cmd/canary/canary.go
@@ -8,15 +8,16 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/Shopify/sarama"
-	"github.com/jeremyary/go-stoker/internal/clients"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/jeremyary/go-stoker/internal/clients"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func main() {
@@ -31,22 +32,31 @@ func main() {
 	rate, _ := os.LookupEnv("PRODUCER_TRAFFIC_SEND_RATE_IN_SEC")
 	clientId, _ := os.LookupEnv("PRODUCER_CLIENT_ID")
 
+	tlsEnabled := false
+	tlsValue, tlsOk := os.LookupEnv("TLS_ENABLED")
+	if tlsOk {
+		tlsEnabled, _ = strconv.ParseBool(tlsValue)
+	}
+
 	sendRateInSec, _ := strconv.Atoi(rate)
 	sendRate := time.Duration(sendRateInSec)
 
-	// setup tls
-	// assumes some Secret mount locations in Pod config!
-	tlsConfig, err := NewTLSConfig(
-		"/etc/client-ca-cert/ca.crt",
-		"/etc/client-ca/ca.key",
-		"/etc/cluster-ca/ca.crt")
-	if err != nil {
-		log.Fatal(err)
+	var tlsConfig *tls.Config
+	if tlsEnabled {
+		// setup tls
+		// assumes some Secret mount locations in Pod config!
+		var err error
+		tlsConfig, err = NewTLSConfig(
+			"/etc/client-ca-cert/ca.crt",
+			"/etc/client-ca/ca.key",
+			"/etc/cluster-ca/ca.crt")
+		if err != nil {
+			log.Fatal(err)
+		}
+		// TODO: verify if this is still needed in-cluster
+		// If insecure is required
+		tlsConfig.InsecureSkipVerify = true
 	}
-
-	// TODO: verify if this is still needed in-cluster
-	// If insecure is required
-	tlsConfig.InsecureSkipVerify = true
 
 	// grab a SyncProducer and a consumer
 	producer, err := clients.InitProducer(bootstrap_url, clientId, tlsConfig)

--- a/cmd/canary/canary.go
+++ b/cmd/canary/canary.go
@@ -33,8 +33,7 @@ func main() {
 	clientId, _ := os.LookupEnv("PRODUCER_CLIENT_ID")
 
 	tlsEnabled := false
-	tlsValue, tlsOk := os.LookupEnv("TLS_ENABLED")
-	if tlsOk {
+	if tlsValue, ok := os.LookupEnv("TLS_ENABLED"); ok {
 		tlsEnabled, _ = strconv.ParseBool(tlsValue)
 	}
 

--- a/internal/clients/producer.go
+++ b/internal/clients/producer.go
@@ -7,12 +7,13 @@ package clients
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/Shopify/sarama"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"log"
 	"os"
 	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
@@ -35,8 +36,10 @@ func InitProducer(url string, clientId string, tlsConfig *tls.Config) (sarama.Sy
 	config.Producer.Retry.Max = 5
 	config.Producer.RequiredAcks = sarama.WaitForAll // bit of an opinion here, tenant req. could vary?
 	config.Producer.Return.Successes = true
-	config.Net.TLS.Enable = true
-	config.Net.TLS.Config = tlsConfig
+	if tlsConfig != nil {
+		config.Net.TLS.Enable = true
+		config.Net.TLS.Config = tlsConfig
+	}
 
 	producer, err := sarama.NewSyncProducer([]string{url}, config)
 	return producer, err


### PR DESCRIPTION
This PR is for making the TLS configuration as optional.
In general, it's useful even for testing purposes without the need to have the TLS certificates in order to connect to a Kafka cluster.