### PR TITLE
Fixed threading model

### DIFF
--- a/cmd/canary/canary.go
+++ b/cmd/canary/canary.go
@@ -23,7 +23,7 @@ func main() {
 
 	fmt.Println("Starting metrics server")
 	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(":8080", nil)
+	go http.ListenAndServe(":8080", nil)
 
 	// fetch canary configuration
 	config := config.NewCanaryConfig()
@@ -57,7 +57,7 @@ func main() {
 	message := "traffic generator payload"
 
 	// send regular messages wrt KAFKA_SEND_RATE_IN_SEC and consume them
-	doEvery(config.SendRate*time.Second, clients.Publish, message, producer, config.Topic)
+	go doEvery(config.SendRate*time.Second, clients.Publish, message, producer, config.Topic)
 	consumer.Consume(config.BootstrapServers, config.Topic, tlsConfig)
 }
 

--- a/internal/clients/consumer.go
+++ b/internal/clients/consumer.go
@@ -40,9 +40,11 @@ func (c *Consumer) Consume(KafkaServer string, KafkaTopic string, tlsConfig *tls
 		panic(err)
 	}
 
-	for err := range group.Errors() {
-		panic(err)
-	}
+	go func() {
+		for err := range group.Errors() {
+			panic(err)
+		}
+	}()
 
 	ctx := context.Background()
 	for {


### PR DESCRIPTION
This PR recovers the threading model for running everything fine.

* the HTTP server for metrics is started in its own go routine
* the Kafka producer is started in its own go routine
* the Kafka consumer uses the main thread but the loop for checking errors run in its own go routine

In order to have everything working, the #9 has to be merged as well for using the canary tool without TLS for testing purposes.